### PR TITLE
Various fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ python3
 virtualenv
 pip
 inotify-tools
+audiotools
 
 ## steps:
 prerequisite install

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ ffmpeg
 python3
 virtualenv
 pip
+inotify-tools
 
 ## steps:
 prerequisite install

--- a/core/Main.py
+++ b/core/Main.py
@@ -60,7 +60,7 @@ def run_emergency_programs():
 
     path = "content/emergency_program"
 
-    time.sleep(60)
+    time.sleep(30)
     print(TAG, "EMERGENCY PROGRAM WATCHER")
 
     while(True):    
@@ -68,7 +68,6 @@ def run_emergency_programs():
 
         for element in elements:
             if element.find(".mp3") >= 0:
-
                 print(TAG," --- emergency program --- ")
                 
                 instant_program = {
@@ -87,8 +86,27 @@ def run_emergency_programs():
                 os.remove(path+'/'+element)
 
                 skip_to_next_track()
+            elif element.find(".ogg") >= 0:
+                print(TAG," --- emergency program --- ")
+                
+                instant_program = {
+                    "title_show" : element.replace(".ogg",""),
+                    "file" : path+'/'+element
+                }
 
-        time.sleep(60)
+                SongDownload.downloadOgg(instant_program)
+
+                current_music_file = Helper.findLastPlayedFile()
+                if( current_music_file.find("A") < 0 ):
+                    copyfile(Constant.default_ogg_download_path, Constant.currentA_path)
+                else:
+                    copyfile(Constant.default_ogg_download_path, Constant.currentB_path)
+
+                os.remove(path+'/'+element)
+
+                skip_to_next_track()
+
+        time.sleep(30)
 
             
 

--- a/core/Main.py
+++ b/core/Main.py
@@ -74,7 +74,6 @@ def run_emergency_programs():
                     "title_show" : element.replace(".mp3",""),
                     "file" : path+'/'+element
                 }
-
                 SongDownload.downloadOgg(instant_program)
 
                 current_music_file = Helper.findLastPlayedFile()
@@ -93,7 +92,6 @@ def run_emergency_programs():
                     "title_show" : element.replace(".ogg",""),
                     "file" : path+'/'+element
                 }
-
                 SongDownload.downloadOgg(instant_program)
 
                 current_music_file = Helper.findLastPlayedFile()
@@ -119,7 +117,7 @@ def setModules():
     FireBaseUtil.initialize(FIREBASE_DB_URL,FIRBASE_CREDENTIAL_PATH)
 
 def skip_to_next_track():
-    os.system('docker exec -it ices_sustcast kill -SIGHUP 1')
+    os.system('docker exec -i ices_sustcast kill -SIGHUP 1')
 
 
 def start_ices():

--- a/core/SongDownload.py
+++ b/core/SongDownload.py
@@ -55,7 +55,19 @@ def downloadOgg(music):
                 #AudioSegment.from_ogg(file_path).export(Constant.default_ogg_download_path, format='ogg',tags={'artist': json.dumps(music), 'title': music['title_show']}, parameters=["-ac", "2"])
                 
                 title = music['title_show']
-                new_title = title.replace(" ", "\ ")
+                def title_replacer(program_title):
+                    temp_title = ""
+                    if " " in program_title:
+                        temp_title = program_title.replace(" ", "\ ")
+                        return temp_title
+
+                    elif ("_") in program_title:
+                        temp_title = program_title.replace("_", "\ ")
+                        return temp_title
+
+                    else:
+                        return program_title
+                new_title = title_replacer(title)
                 new_music = file_path.replace(" ", "\ ")
                 os.system(f"tracktag --name {new_title} {new_music}")
 

--- a/core/SongDownload.py
+++ b/core/SongDownload.py
@@ -47,12 +47,16 @@ def downloadOgg(music):
     
     elif 'file' in music:
         file_path = music['file']
+        print("Converting")
+        if(file_path.split(".")[-1]!='ogg'):
+                AudioSegment.from_mp3(file_path).export(Constant.default_ogg_download_path, format='ogg',tags={'artist': json.dumps(music), 'title': music['title_show']}, parameters=["-ac", "2"])
+                print("Conversion Done")
+        else:
+                #AudioSegment.from_ogg(file_path).export(Constant.default_ogg_download_path, format='ogg',tags={'artist': json.dumps(music), 'title': music['title_show']}, parameters=["-ac", "2"])
+                copyfile(file_path, Constant.default_ogg_download_path)
+                print("ogg file copied succesfully.")
 
-        AudioSegment.from_mp3(file_path).export(Constant.default_ogg_download_path, format='ogg',tags={'artist': json.dumps(music), 'title': music['title_show']}, parameters=["-ac", "2"])
-        
         return True
 
     return False
 
-    
-        

--- a/core/SongDownload.py
+++ b/core/SongDownload.py
@@ -53,6 +53,11 @@ def downloadOgg(music):
                 print("Conversion Done")
         else:
                 #AudioSegment.from_ogg(file_path).export(Constant.default_ogg_download_path, format='ogg',tags={'artist': json.dumps(music), 'title': music['title_show']}, parameters=["-ac", "2"])
+                
+                title = music['title']
+                new_title = title.replace(" ", "\ ")
+                os.system(f"tracktag --name {new_title} {music}")
+                
                 copyfile(file_path, Constant.default_ogg_download_path)
                 print("ogg file copied succesfully.")
 

--- a/core/SongDownload.py
+++ b/core/SongDownload.py
@@ -54,7 +54,7 @@ def downloadOgg(music):
         else:
                 #AudioSegment.from_ogg(file_path).export(Constant.default_ogg_download_path, format='ogg',tags={'artist': json.dumps(music), 'title': music['title_show']}, parameters=["-ac", "2"])
                 
-                title = music['title']
+                title = music['title_show']
                 new_title = title.replace(" ", "\ ")
                 new_music = file_path.replace(" ", "\ ")
                 os.system(f"tracktag --name {new_title} {new_music}")

--- a/core/SongDownload.py
+++ b/core/SongDownload.py
@@ -56,8 +56,9 @@ def downloadOgg(music):
                 
                 title = music['title']
                 new_title = title.replace(" ", "\ ")
-                os.system(f"tracktag --name {new_title} {music}")
-                
+                new_music = file_path.replace(" ", "\ ")
+                os.system(f"tracktag --name {new_title} {new_music}")
+
                 copyfile(file_path, Constant.default_ogg_download_path)
                 print("ogg file copied succesfully.")
 

--- a/core/content/file_checker.sh
+++ b/core/content/file_checker.sh
@@ -3,5 +3,5 @@
 while ! inotifywait -e modify program_schedule.csv; do 
 	pkill -f start.sh
 	pkill -f Main.py
-	bash /home/ubuntu/Workspace/sustcast-core-v0/startTest.sh &
+	bash /home/ubuntu/Workspace/sustcast-core-v0/start.sh &
 done

--- a/core/content/file_checker.sh
+++ b/core/content/file_checker.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+while ! inotifywait -e modify program_schedule.csv; do 
+	pkill -f start.sh
+	pkill -f Main.py
+	bash /home/ubuntu/Workspace/sustcast-core-v0/startTest.sh &
+done

--- a/core/req.txt
+++ b/core/req.txt
@@ -50,4 +50,3 @@ urllib3==1.25.9
 youtube-dl==2020.5.29
 youtube-search==0.1.3
 nltk==3.5
-music-tag==0.4.2

--- a/core/req.txt
+++ b/core/req.txt
@@ -50,3 +50,4 @@ urllib3==1.25.9
 youtube-dl==2020.5.29
 youtube-search==0.1.3
 nltk==3.5
+music-tag==0.4.2

--- a/start.sh
+++ b/start.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-cd core/
+cd /home/ubuntu/Workspace/sustcast-core-v0/core/
 source venv/bin/activate
 python Main.py
 cd ..

--- a/stop.sh
+++ b/stop.sh
@@ -1,2 +1,5 @@
 #!/bin/bash
+pkill -f start.sh
+pkill -f Main.py
+pkill -f file_checker.sh
 docker-compose -f ices-docker/docker-compose.yml down

--- a/stop.sh
+++ b/stop.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-docker-compose -f ../ices-docker/docker-compose.yml down
+docker-compose -f ices-docker/docker-compose.yml down

--- a/stop.sh
+++ b/stop.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+docker-compose -f ../ices-docker/docker-compose.yml down


### PR DESCRIPTION
1. Fix timezone
2. Fix scheduling
3. Add stop script for docker
4. Partially fix ram issue ( we aren't using `pydub` for copying ogg files)

For now **only** `ogg` programs can be aired because converting of mp3 somehow or other depends on `ffmpeg`. Currently we do not have any similar alternative library to do this.

The scheduling system will work if and only if `program_schedule.csv` file is edited using `vim`.

Files copied in `programs` directory, will have a title of the file name and underscores ( `_` ) will be automatically converted to spaces.


For watching changes in `program_schedule.csv`, the `file_checker.sh` script should be started using:
`nohup bash file_checker.sh`
